### PR TITLE
Fix typo in radio update comment

### DIFF
--- a/dcs_srs/messages.py
+++ b/dcs_srs/messages.py
@@ -20,7 +20,7 @@ class MessageType(IntEnum):
     SYNC = 2
 
     # Client sends to update server about radio states
-    # Server sends to client radio info one changes (if showing tune count)
+    # Server sends to client radio info on changes (if showing tune count)
     RADIO_UPDATE = 3
 
     # Client sends to trigger server to broadcast its settings


### PR DESCRIPTION
## Summary
- fix typo in `RADIO_UPDATE` comment

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fec3af6248325a79a4e8640b5e805